### PR TITLE
Refactoring: ContextSearch simplification

### DIFF
--- a/src/dotnet/ReSharperPlugin.TestLinker/Navigation/LinkedTypesContextSearchBase.cs
+++ b/src/dotnet/ReSharperPlugin.TestLinker/Navigation/LinkedTypesContextSearchBase.cs
@@ -1,44 +1,20 @@
-using System.Linq;
 using JetBrains.Application.DataContext;
-using JetBrains.Diagnostics;
-using JetBrains.ProjectModel.DataContext;
-using JetBrains.ReSharper.Feature.Services.Navigation;
 using JetBrains.ReSharper.Feature.Services.Navigation.ContextNavigation;
 using JetBrains.ReSharper.Psi;
-using JetBrains.ReSharper.Psi.CSharp;
-using JetBrains.ReSharper.Psi.DataContext;
 using JetBrains.ReSharper.Psi.ExtensionsAPI.Caches2;
 using JetBrains.TextControl;
 using JetBrains.TextControl.DataContext;
-using JetBrains.Util;
-using ReSharperPlugin.TestLinker.Utils;
 
 namespace ReSharperPlugin.TestLinker.Navigation
 {
-    public abstract class LinkedTypesContextSearchBase : IContextSearch
+    public abstract class LinkedTypesContextSearchBase : DeclaredElementContextSearchBase<LinkedTypesSearchRequest>
     {
-        public bool IsAvailable(IDataContext dataContext)
+        protected override LinkedTypesSearchRequest CreateSearchRequest(IDataContext dataContext, IDeclaredElement element,
+            IDeclaredElement initialTarget)
         {
-            return true;
-        }
-
-        public bool IsContextApplicable(IDataContext dataContext)
-        {
-            return ContextNavigationUtil.CheckDefaultApplicability<CSharpLanguage>(dataContext);
-        }
-
-        public LinkedTypesSearchRequest CreateSearchRequest(IDataContext dataContext)
-        {
-            var typesFromTextControlService = dataContext.GetComponent<ITypesFromTextControlService>().NotNull();
             var textControl = dataContext.GetData(TextControlDataConstants.TEXT_CONTROL);
-            var solution = dataContext.GetData(ProjectModelDataConstants.SOLUTION);
 
-            var declaredElements = dataContext.GetData(PsiDataConstants.DECLARED_ELEMENTS_FROM_ALL_CONTEXTS);
-            // TODO: static classes appear twice
-            var type = declaredElements?.OfType<ClassLikeTypeElement>().Distinct(x => x.ToString()).SingleOrFirstOrDefaultErr()
-                       ?? typesFromTextControlService.GetTypesFromCaretOrFile(textControl.NotNull(), solution.NotNull()).SingleOrFirstOrDefaultErr();
-
-            return type != null ? CreateSearchRequest(type, textControl) : null;
+            return element is ClassLikeTypeElement type ? CreateSearchRequest(type, textControl) : null;
         }
 
         protected abstract LinkedTypesSearchRequest CreateSearchRequest(ITypeElement type, ITextControl textControl);

--- a/src/dotnet/ReSharperPlugin.TestLinker/Navigation/LinkedTypesNavigationProvider.cs
+++ b/src/dotnet/ReSharperPlugin.TestLinker/Navigation/LinkedTypesNavigationProvider.cs
@@ -1,5 +1,4 @@
 using JetBrains.Application;
-using JetBrains.Application.DataContext;
 using JetBrains.Application.Threading;
 using JetBrains.Application.UI.Tooltips;
 using JetBrains.ReSharper.Feature.Services.Navigation.ContextNavigation;
@@ -15,18 +14,18 @@ namespace ReSharperPlugin.TestLinker.Navigation
             IShellLocks locks,
             ITooltipManager tooltipManager,
             IFeaturePartsContainer manager)
-            : base(locks, tooltipManager, manager)
+            : base(manager)
         {
         }
 
-        protected override string GetActionId(IDataContext dataContext)
+        protected override string ActionId
         {
-            return GotoLinkedTypesAction.Id;
+            get { return GotoLinkedTypesAction.Id; }
         }
 
-        protected override string GetNavigationMenuTitle(IDataContext dataContext)
+        protected override string NavigationMenuTitle
         {
-            return "Linked Types";
+            get { return "Linked Types"; }
         }
     }
 }

--- a/src/dotnet/ReSharperPlugin.TestLinker/Navigation/LinkedTypesWithDerivedNameNavigationProvider.cs
+++ b/src/dotnet/ReSharperPlugin.TestLinker/Navigation/LinkedTypesWithDerivedNameNavigationProvider.cs
@@ -1,5 +1,4 @@
 using JetBrains.Application;
-using JetBrains.Application.DataContext;
 using JetBrains.Application.Threading;
 using JetBrains.Application.UI.Tooltips;
 using JetBrains.ReSharper.Feature.Services.Navigation.ContextNavigation;
@@ -15,18 +14,12 @@ namespace ReSharperPlugin.TestLinker.Navigation
             IShellLocks locks,
             ITooltipManager tooltipManager,
             IFeaturePartsContainer manager)
-            : base(locks, tooltipManager, manager)
+            : base(manager)
         {
         }
-        
-        protected override string GetActionId(IDataContext dataContext)
-        {
-            return GotoLinkedTypesWithDerivedNameAction.Id;
-        }
-        
-        protected override string GetNavigationMenuTitle(IDataContext dataContext)
-        {
-            return "Linked Types With Derived Name";
-        }
+
+        protected override string ActionId => GotoLinkedTypesWithDerivedNameAction.Id;
+
+        protected override string NavigationMenuTitle => "Linked Types With Derived Name";
     }
 }


### PR DESCRIPTION
Existing support classes can be used from SDK. This change should
simplify code and provide opportunity to obtain ISearchResultPresenter.